### PR TITLE
feat: add cache exceptions documentation

### DIFF
--- a/configuration/cache.md
+++ b/configuration/cache.md
@@ -175,6 +175,27 @@ _mutable_ tag), the image associated with that tag may change and not cause a
 call cache entry to be invalidated.
 :::
 
+## Call cache configuration
+
+::: warning Warning
+Configuring the call cache invalidation can lead to incorrect reuse of results.
+Ensure any excepted fields do not impact the result of a task.
+:::
+
+The invalidation logic for cache entries is configurable. Keys in `input`, 
+`requirements`, and/or `hints` can be excluded from caching checking. Any `input` 
+keys specified will also alter the digest used as a key for the cache and changes
+to the list will trigger rerun of any affected tasks. Keys added to `hints` or 
+`requirements` will be applied to existing cache entries since they do not affect
+the cache key digest.
+
+```toml
+[run.task]
+excluded_cache_inputs = []
+excluded_cache_hints = []
+excluded_cache_requirements = []
+```
+
 ## Logged messages
 
 Sprocket will log an `INFO` level message indicating when it reuses or

--- a/configuration/cache.md
+++ b/configuration/cache.md
@@ -189,12 +189,19 @@ to the list will trigger rerun of any affected tasks. Keys added to `hints` or
 `requirements` will be applied to existing cache entries since they do not affect
 the cache key digest.
 
+These options are configured under `[run.task]` in your `sprocket.toml`:
+
 ```toml
 [run.task]
-excluded_cache_inputs = []
-excluded_cache_hints = []
-excluded_cache_requirements = []
+excluded_cache_requirements = ["cpu", "memory"]
+excluded_cache_hints = ["maxRetries"]
+excluded_cache_inputs = ["runtime_param"]
 ```
+
+- `excluded_cache_requirements` — requirement keys to ignore when checking
+  cache validity.
+- `excluded_cache_hints` — hint keys to ignore when checking cache validity.
+- `excluded_cache_inputs` — input keys to ignore when checking cache validity.
 
 ## Logged messages
 


### PR DESCRIPTION
Document the configuration keys for excluding `input`, `hints`, and/or `requirements` from cache checking.