### PR TITLE
docs: updates for v0.22.0

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -16,7 +16,7 @@ export default defineConfig({
     nav: [
       { text: "Documentation", link: "/overview" },
       {
-        text: "v0.21.1",
+        text: "v0.22.0",
         items: [
           {
             text: "Changelog",

--- a/configuration/backends/lsf.md
+++ b/configuration/backends/lsf.md
@@ -83,6 +83,14 @@ type = "lsf_apptainer"
 # Additional command-line arguments to pass to `apptainer exec` when executing
 # tasks.
 # extra_apptainer_exec_args = ["--hostname=\"my_host\""]
+
+# Path to the Apptainer (or Singularity) executable. Defaults to `"apptainer"`.
+# Set to `"singularity"` or a full path if the executable is not on `PATH`.
+# executable = "apptainer"
+
+# Shared directory for caching pulled `.sif` images across runs. When unset,
+# images are stored per-run and not shared.
+# image_cache_dir = "/shared/containers/cache"
 ```
 
 If you run into problems or have other feedback, please reach out to us in the

--- a/configuration/backends/slurm.md
+++ b/configuration/backends/slurm.md
@@ -68,6 +68,29 @@ fpga_slurm_partition.name = "fpga"
 # Additional command-line arguments to pass to `sbatch` when submitting jobs
 # to Slurm.
 extra_sbatch_args = ["--time=60"]
+
+# The maximum number of concurrent Slurm operations the backend will perform.
+# Defaults to `10`. Consider raising this for large-scale workflow execution.
+# max_concurrency = 10
+
+# Prefix added to every Slurm job name. Useful for identifying Sprocket jobs
+# in `squeue` output (e.g., `squeue -n "sprocket*"`).
+# job_name_prefix = "sprocket"
+
+# Task monitor polling interval in seconds. Defaults to `30`.
+# interval = 30
+
+# Additional command-line arguments to pass to `apptainer exec` when executing
+# tasks.
+# extra_apptainer_exec_args = ["--hostname=\"my_host\""]
+
+# Path to the Apptainer (or Singularity) executable. Defaults to `"apptainer"`.
+# Set to `"singularity"` or a full path if the executable is not on `PATH`.
+# executable = "apptainer"
+
+# Shared directory for caching pulled `.sif` images across runs. When unset,
+# images are stored per-run and not shared.
+# image_cache_dir = "/shared/containers/cache"
 ```
 
 If you run into problems or have other feedback, please reach out to us in the

--- a/configuration/cache.md
+++ b/configuration/cache.md
@@ -168,6 +168,11 @@ when it detects a change.
 
 ## Cache exclusion options
 
+::: warning Warning
+Excluding fields from cache checking can lead to incorrect reuse of results.
+Ensure any excluded fields do not impact the result of a task.
+:::
+
 You can exclude specific requirements, hints, or inputs from cache key
 computation. This is useful for dynamic resource allocation (where CPU or
 memory may vary between runs) or inputs that do not affect a task's output.
@@ -182,9 +187,13 @@ excluded_cache_inputs = ["runtime_param"]
 ```
 
 - `excluded_cache_requirements` — requirement keys to ignore when checking
-  cache validity.
+  cache validity. Exclusions apply retroactively to existing cache entries
+  since requirements do not affect the cache key digest.
 - `excluded_cache_hints` — hint keys to ignore when checking cache validity.
+  Like requirements, exclusions apply retroactively to existing cache entries.
 - `excluded_cache_inputs` — input keys to ignore when checking cache validity.
+  Because inputs contribute to the cache key digest, changes to this list will
+  trigger reruns of any affected tasks.
 
 ::: warning Warning
 The call cache will not detect changes to the _image_ used for the task's

--- a/configuration/cache.md
+++ b/configuration/cache.md
@@ -166,6 +166,26 @@ modified), the cache entry is _invalidated_.
 Sprocket will log a message indicating which of the above have been modified
 when it detects a change.
 
+## Cache exclusion options
+
+You can exclude specific requirements, hints, or inputs from cache key
+computation. This is useful for dynamic resource allocation (where CPU or
+memory may vary between runs) or inputs that do not affect a task's output.
+
+These options are configured under `[run.task]` in your `sprocket.toml`:
+
+```toml
+[run.task]
+excluded_cache_requirements = ["cpu", "memory"]
+excluded_cache_hints = ["maxRetries"]
+excluded_cache_inputs = ["runtime_param"]
+```
+
+- `excluded_cache_requirements` — requirement keys to ignore when checking
+  cache validity.
+- `excluded_cache_hints` — hint keys to ignore when checking cache validity.
+- `excluded_cache_inputs` — input keys to ignore when checking cache validity.
+
 ::: warning Warning
 The call cache will not detect changes to the _image_ used for the task's
 execution.

--- a/guides/lsf.md
+++ b/guides/lsf.md
@@ -163,6 +163,14 @@ default_lsf_queue.max_memory_per_task = "96 GB"
 # Additional arguments passed to `apptainer exec`.
 # For example, pass `--nv` to enable GPU support inside containers.
 # extra_apptainer_exec_args = ["--nv"]
+
+# Path to the Apptainer (or Singularity) executable. Defaults to `"apptainer"`.
+# Set to `"singularity"` or a full path if the executable is not on `PATH`.
+# executable = "apptainer"
+
+# Shared directory for caching pulled `.sif` images across runs. When unset,
+# images are stored per-run and not shared.
+# image_cache_dir = "/shared/containers/cache"
 ```
 
 ### Resource limit behavior
@@ -291,9 +299,22 @@ multiple of this number.
 Sprocket pulls container images and converts them to SIF files in an
 `apptainer-images/` directory inside each run's timestamped directory. A given
 image is only pulled once within a run, but each new run pulls all of its
-images fresh. For workflows that use many large images, you can pre-pull
-images to a shared location using `apptainer pull` and reference the local SIF
-path in your WDL `container` declarations:
+images fresh.
+
+The preferred way to share images across runs is to set `image_cache_dir` in
+your backend configuration:
+
+```toml
+[run.backends.default]
+image_cache_dir = "/shared/containers/cache"
+```
+
+When set, Sprocket stores pulled `.sif` images in this directory and reuses
+them for subsequent runs, avoiding repeated downloads.
+
+Alternatively, you can pre-pull images to a shared location using
+`apptainer pull` and reference the local SIF path in your WDL `container`
+declarations:
 
 ```shell
 apptainer pull /shared/containers/ubuntu_latest.sif docker://ubuntu:latest
@@ -374,7 +395,10 @@ run directory structure.
 - **Apptainer not found on compute nodes.** Ensure Apptainer is installed and
   on the `PATH` for LSF jobs. If Apptainer is provided via an environment
   module, it must be loaded in the user's environment before running
-  `sprocket run` so that the job inherits the correct `PATH`.
+  `sprocket run` so that the job inherits the correct `PATH`. You can also
+  set the `executable` option in `[run.backends.default]` to
+  `"singularity"` or a full path to the binary if it is not named
+  `apptainer` or is not on `PATH`.
 
 ### Getting help
 

--- a/guides/slurm.md
+++ b/guides/slurm.md
@@ -152,6 +152,26 @@ default_slurm_partition.max_memory_per_task = "96 GB"
 # Additional arguments passed to `apptainer exec`.
 # For example, pass `--nv` to enable GPU support inside containers.
 # extra_apptainer_exec_args = ["--nv"]
+
+# Maximum number of concurrent `sbatch` processes the backend will spawn to
+# queue tasks. Defaults to `10`. Consider raising this for large-scale
+# workflow execution.
+# max_concurrency = 10
+
+# Prefix added to every Slurm job name. Useful for identifying Sprocket jobs
+# in `squeue` output.
+# job_name_prefix = "sprocket"
+
+# Task monitor polling interval in seconds. Defaults to `30`.
+# interval = 30
+
+# Path to the Apptainer (or Singularity) executable. Defaults to `"apptainer"`.
+# Set to `"singularity"` or a full path if the executable is not on `PATH`.
+# executable = "apptainer"
+
+# Shared directory for caching pulled `.sif` images across runs. When unset,
+# images are stored per-run and not shared.
+# image_cache_dir = "/shared/containers/cache"
 ```
 
 ### Resource limit behavior
@@ -252,7 +272,16 @@ and compute nodes can access it. Use the `-o` flag to specify the location:
 sprocket run workflow.wdl --target main -o /shared/results/my-project
 ```
 
-### Scatter concurrency
+### Concurrency
+
+The `max_concurrency` setting controls how many `sbatch` processes the backend
+will spawn concurrently to queue tasks. The default is `10`, which you may want
+to raise for large-scale workflow execution:
+
+```toml
+[run.backends.default]
+max_concurrency = 10
+```
 
 The `run.workflow.scatter.concurrency` setting controls how many elements within a
 `scatter` block are evaluated concurrently. The default is `1000`:
@@ -261,19 +290,32 @@ The `run.workflow.scatter.concurrency` setting controls how many elements within
 run.workflow.scatter.concurrency = 1000
 ```
 
-Setting this too high can put pressure on the scheduler by queueing a large
-number of jobs at once. Note that each scattered task may itself request
-multiple CPUs, so the actual resource consumption can be a multiple of this
-number.
+Setting scatter concurrency too high can put pressure on the scheduler by
+queueing a large number of jobs at once. Note that each scattered task may
+itself request multiple CPUs, so the actual resource consumption can be a
+multiple of this number.
 
 ### Container image caching
 
 Sprocket pulls container images and converts them to SIF files in an
 `apptainer-images/` directory inside each run's timestamped directory. A given
 image is only pulled once within a run, but each new run pulls all of its
-images fresh. For workflows that use many large images, you can pre-pull
-images to a shared location using `apptainer pull` and reference the local SIF
-path in your WDL `container` declarations:
+images fresh.
+
+The preferred way to share images across runs is to set `image_cache_dir` in
+your backend configuration:
+
+```toml
+[run.backends.default]
+image_cache_dir = "/shared/containers/cache"
+```
+
+When set, Sprocket stores pulled `.sif` images in this directory and reuses
+them for subsequent runs, avoiding repeated downloads.
+
+Alternatively, you can pre-pull images to a shared location using
+`apptainer pull` and reference the local SIF path in your WDL `container`
+declarations:
 
 ```shell
 apptainer pull /shared/containers/ubuntu_latest.sif docker://ubuntu:latest
@@ -347,7 +389,10 @@ run directory structure.
 - **Apptainer not found on compute nodes.** Ensure Apptainer is installed and
   on the `PATH` for Slurm jobs. If Apptainer is provided via an environment
   module, it must be loaded in the user's environment before running
-  `sprocket run` so that the job inherits the correct `PATH`.
+  `sprocket run` so that the job inherits the correct `PATH`. You can also
+  set the `executable` option in `[run.backends.default]` to
+  `"singularity"` or a full path to the binary if it is not named
+  `apptainer` or is not on `PATH`.
 
 ### Getting help
 

--- a/subcommands/format.md
+++ b/subcommands/format.md
@@ -15,6 +15,11 @@ the subcommand.
 
 ## Input formatting
 
+> [!NOTE]
+>
+> Input sorting is disabled by default. To enable it, set `sort_inputs = true`
+> in the `[format]` section of your `sprocket.toml`.
+
 Sprocket has an opinionated order for WDL `input` sections.
 
 First, it sorts by:
@@ -41,3 +46,10 @@ Within each of those groupings, inputs are further sorted by WDL type:
 For ordering of the same compound type (`Array[\*]`, `Map[\*, \*]`, `Pair[\*, \*]`), Sprocket drops the outermost type (`Array`, `Map`, `Pair`) and recursively applies the above sorting on the first inner type, with ties broken by the second inner type. This continues as far as possible.
 
 Once this ordering is satisfied, it is up to the developer for final order of inputs of the same type. Sprocket `format` will preserve relative ordering within types.
+
+## Trailing commas
+
+The formatter automatically adds trailing commas to multiline lists (e.g.,
+`meta`, `parameter_meta`, and `runtime` sections). This is enabled by default
+and can be configured via the `trailing_commas` option in the `[format]`
+section of your `sprocket.toml`.

--- a/subcommands/run.md
+++ b/subcommands/run.md
@@ -116,6 +116,17 @@ Individual runs are stored at `<output_dir>/runs/<target>/<timestamp>/`, and a
 The output directory also contains a SQLite provenance database (`sprocket.db`)
 that tracks all executions.
 
+The `--suffix` flag appends a user-defined string to the run directory name,
+producing `<timestamp>_<suffix>` instead of just `<timestamp>`. This is useful
+for identifying runs at a glance:
+
+```shell
+sprocket run example.wdl --target main name="World" --suffix experiment-1
+```
+
+This changes the run directory from `out/runs/main/<timestamp>/` to
+`out/runs/main/<timestamp>_experiment-1/`.
+
 The `--index-on` flag enables output indexing, creating symlinks under
 `<output_dir>/index/<output_name>/` for efficient lookup of runs by output
 values.


### PR DESCRIPTION
Documents the user-facing changes in Sprocket v0.22.0 across the docs site.

The version badge is bumped from v0.21.1 to v0.22.0, and the following new features are covered:

- **Apptainer configuration.**`executable` and `image_cache_dir` options added to all four backend pages (LSF and Slurm reference + guide). The "Container image caching" sections now recommend `image_cache_dir` as the preferred approach, and the "Apptainer not found" troubleshooting entries mention the `executable` option.
- **Slurm concurrency and monitoring.** `max_concurrency`, `job_name_prefix`, and `interval` added to the Slurm backend reference and guide (bringing it to parity with LSF). A new "Concurrency" section in the Slurm guide mirrors the one in the LSF guide.
- **`--suffix` flag.** documented on the `sprocket run` page, explaining how it changes the run directory name.
- **Cache exclusion options.** new section on the call cache page for `excluded_cache_requirements`, `excluded_cache_hints`, and `excluded_cache_inputs`.
- **Formatter changes.** note that input sorting is now off by default (`sort_inputs`), and a new "Trailing commas" section for the `trailing_commas` option.