### PR TITLE
docs: adds quickstart checklist page

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -32,6 +32,7 @@ export default defineConfig({
           { text: "Overview", link: "/overview", docFooterText: "Getting Started &gt; Overview" },
           { text: "Project Status", link: "/project-status", docFooterText: "Getting Started &gt; Project Status" },
           { text: "Installation", link: "/installation", docFooterText: "Getting Started &gt; Installation" },
+          { text: "Quickstart Checklist", link: "/quickstart-checklist", docFooterText: "Getting Started &gt; Quickstart Checklist" },
           { text: "Guided Tour", link: "/guided-tour", docFooterText: "Getting Started &gt; Guided Tour" },
         ],
       },

--- a/guided-tour.md
+++ b/guided-tour.md
@@ -179,7 +179,7 @@ appear as `null`.
 
 You can save this to a file, fill in the values, and pass it directly to
 `sprocket run`. The `--hide-defaults` flag narrows the output to only the
-required inputs, and `--show-expressions` includes expression values. See the
+required inputs, and `--show-non-literals` includes expression values. See the
 [`sprocket inputs`](/subcommands/inputs) reference for details.
 
 ## Running tasks and workflows

--- a/guided-tour.md
+++ b/guided-tour.md
@@ -99,6 +99,26 @@ This leaves a single diagnostic, which is that `color` is an unused workflow
 input. Before continuing on, we will remove that input from the `main` workflow
 so it doesn't continue showing up in the diagnostics.
 
+### Formatting
+
+Sprocket includes an opinionated formatter that keeps your WDL documents
+consistent. You can check whether a document is already formatted correctly
+without modifying it:
+
+```shell
+sprocket format check example.wdl
+```
+
+To apply formatting in place, use the `overwrite` mode:
+
+```shell
+sprocket format overwrite example.wdl
+```
+
+The formatter handles indentation, whitespace, and input ordering (when
+enabled). See the [`sprocket format`](/subcommands/format) reference for the
+full set of configuration options.
+
 ### Continuous integration
 
 If you use GitHub for source control, you can use the [Sprocket GitHub
@@ -127,6 +147,40 @@ provides similar integration.
 
 For other editors, please refer to their documentation on how to configure the
 Sprocket LSP (i.e., `sprocket analyzer`).
+
+## Generating input templates
+
+Before running a workflow, it can be helpful to see what inputs it expects. The
+`sprocket inputs` subcommand generates a template input JSON file for a given
+task or workflow:
+
+```shell
+sprocket inputs example.wdl --name main
+```
+
+This produces a JSON object with placeholders for each input:
+
+```json
+{
+  "main.name": "String <REQUIRED>",
+  "main.greetings": [
+    "Hello",
+    "Hallo",
+    "Hej"
+  ],
+  "main.color": "green",
+  "main.is_pirate": false
+}
+```
+
+Required inputs are marked with `<REQUIRED>` and their type, while inputs with
+defaults show their default values directly. Optional inputs without defaults
+appear as `null`.
+
+You can save this to a file, fill in the values, and pass it directly to
+`sprocket run`. The `--hide-defaults` flag narrows the output to only the
+required inputs, and `--show-expressions` includes expression values. See the
+[`sprocket inputs`](/subcommands/inputs) reference for details.
 
 ## Running tasks and workflows
 

--- a/quickstart-checklist.md
+++ b/quickstart-checklist.md
@@ -1,0 +1,52 @@
+# Quickstart Checklist
+
+This page is for people new to the Sprocket project who want to understand how
+to adopt it on their own project. Work through the items below to get your
+development environment, CI pipeline, and workflow execution set up.
+
+## Development environment
+
+- [ ] **Install Sprocket.** Get the `sprocket` CLI on your machine via
+  Homebrew, direct download, or from source. See the
+  [Installation](/installation) page.
+
+- [ ] **Set up your editor.** Install the
+  [VSCode extension](https://marketplace.visualstudio.com/items?itemName=stjude-rust-labs.sprocket-vscode)
+  or the [Neovim plugin](https://github.com/stjude-rust-labs/sprocket.nvim)
+  for inline diagnostics and syntax highlighting. See the
+  [VSCode guide](/vscode/getting-started) for details.
+
+- [ ] **Generate shell completions.** Enable tab completion for commands and
+  arguments in your shell. See
+  [Shell completions](/installation#shell-completions).
+
+## Code quality
+
+- [ ] **Lint your WDL documents.** Run `sprocket lint` to catch validation
+  errors and style issues early. See the
+  [Guided Tour](/guided-tour#ensuring-high-quality-code) for a walkthrough.
+
+- [ ] **Format your WDL documents.** Run `sprocket format overwrite` to
+  maintain consistent style across your project. See the
+  [format command](/subcommands/format) reference.
+
+- [ ] **Add the GitHub Action.** Add the
+  [Sprocket GitHub Action](https://github.com/stjude-rust-labs/sprocket-action)
+  to your CI pipeline so that linting and formatting are checked on every pull
+  request.
+
+## Running workflows
+
+- [ ] **Run your first workflow.** Execute a task or workflow with
+  `sprocket run`. The [Guided Tour](/guided-tour#running-tasks-and-workflows)
+  walks through a complete example.
+
+- [ ] **Configure an execution backend.** If you are running on an HPC cluster
+  or a TES endpoint, configure a backend in your `sprocket.toml`. See the
+  [Execution Backends](/configuration/backends/overview) overview.
+
+## Community
+
+- [ ] **Join the conversation.** The `#sprocket` channel on the
+  [OpenWDL Slack](https://join.slack.com/t/openwdl/shared_invite/zt-ctmj4mhf-cFBNxIiZYs6SY9HgM9UAVw)
+  is the best place for questions, feedback, and discussion.

--- a/subcommands/inputs.md
+++ b/subcommands/inputs.md
@@ -3,8 +3,8 @@
 The `inputs` subcommand generates a template input JSON file for a given task or
 workflow.
 
-The `--show-expressions` option includes expression values for inputs in the
-template.
+The `--show-non-literals` option includes inputs whose default values are
+non-literal expressions in the template.
 
 The `--hide-defaults` option hides any inputs with default values, allowing you
 to focus only on the required inputs.


### PR DESCRIPTION
This adds a new "Quickstart Checklist" page under Getting Started aimed at people new to Sprocket who want to understand how to adopt it on their project. Rather than duplicating the guided tour or installation docs, it provides a scannable checklist of everything to set up — CLI installation, editor plugins, shell completions, linting, formatting, the GitHub Action, running workflows, backend configuration, and joining the community — with links out to the relevant pages for details.