### PR TITLE
docs: Unify output_dir naming in documentation

### DIFF
--- a/concepts/provenance.md
+++ b/concepts/provenance.md
@@ -62,10 +62,9 @@ By default, Sprocket creates an `out/` directory in your current working
 directory to store all workflow outputs and provenance data. This location can
 be configured via:
 
-- The `-o, --output-dir` CLI flag (for `sprocket run`).
-- The `-o, --output-directory` CLI flag (for `sprocket dev server`).
+- The `-o, --output-dir` CLI flag (for `sprocket run` and `sprocket dev server`).
 - The `run.output_dir` configuration option (for run mode).
-- The `server.output_directory` configuration option (for server mode).
+- The `server.output_dir` configuration option (for server mode).
 
 ### Directory structure
 

--- a/subcommands/server.md
+++ b/subcommands/server.md
@@ -38,7 +38,7 @@ indicate where workflow sources can be loaded from.
 | `--host <HOST>` | Host to bind to (default: `127.0.0.1`) |
 | `--port <PORT>` | Port to bind to (default: `8080`) |
 | `--database-url <URL>` | Database path. When omitted, defaults to `sprocket.db` within the output directory. When provided, relative paths resolve from the current working directory. |
-| `-o, --output-directory <DIR>` | Output directory for workflow results (default: `./out`) |
+| `-o, --output-dir <DIR>` | Output directory for workflow results (default: `./out`) |
 | `--allowed-file-paths <PATH>` | Allowed file paths for file-based workflows (can be repeated) |
 | `--allowed-urls <URL>` | Allowed URL prefixes for URL-based workflows (can be repeated) |
 | `--allowed-origins <ORIGIN>` | Allowed CORS origins (can be repeated) |
@@ -51,7 +51,7 @@ Server settings can also be configured in `sprocket.toml`:
 [server]
 host = "127.0.0.1"
 port = 8080
-output_directory = "./out"
+output_dir = "./out"
 allowed_file_paths = ["/path/to/workflows"]
 allowed_urls = ["https://raw.githubusercontent.com/"]
 allowed_origins = ["http://localhost:3000"]
@@ -70,7 +70,7 @@ url = "sqlite://sprocket.db"
 |--------|------|---------|-------------|
 | `host` | String | `"127.0.0.1"` | Host address to bind |
 | `port` | Integer | `8080` | Port to bind |
-| `output_directory` | Path | `"./out"` | Directory for workflow outputs |
+| `output_dir` | Path | `"./out"` | Directory for workflow outputs |
 | `allowed_file_paths` | List | `[]` | Allowed local paths for workflow sources |
 | `allowed_urls` | List | `[]` | Allowed URL prefixes for workflow sources |
 | `allowed_origins` | List | `[]` | CORS allowed origins |


### PR DESCRIPTION
Corresponds to https://github.com/stjude-rust-labs/sprocket/pull/777 which renames `--output-directory` to `--output-dir` for `dev server` subcommand and rename `output_directory` to `output_dir` in `[server]` config table