### PR TITLE
Documents array inputs and `submit` subcommand

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -94,6 +94,7 @@ export default defineConfig({
           { text: "doc", link: "/subcommands/doc", docFooterText: "Experimental Commands &gt; doc" },
           { text: "lock", link: "/subcommands/lock", docFooterText: "Experimental Commands &gt; lock" },
           { text: "server", link: "/subcommands/server", docFooterText: "Experimental Commands &gt; server" },
+          { text: "submit", link: "/subcommands/submit", docFooterText: "Experimental Commands &gt; submit" },
           { text: "test", link: "/subcommands/test", docFooterText: "Experimental Commands &gt; test" },
         ]
       },

--- a/guided-tour.md
+++ b/guided-tour.md
@@ -221,11 +221,11 @@ must be provided before the workflow can run.
 Inputs to a Sprocket run are provided as arguments passed after the WDL document
 name is provided. Each input can be specified as either
 
-* a key value pair (e.g., `main.is_pirate=true`)
-* a JSON file containing inputs (e.g., a `hello_defaults.json` file where the
-  contents are `{ "main.is_pirate": true }`)
-* a YAML file containing inputs (e.g. a `hello_defaults.yaml` file where the
-  contents are `main.is_pirate: true`)
+* a key-value pair (e.g., `main.is_pirate=true`),
+* a JSON file of inputs prefixed with `@` (e.g., `@hello_defaults.json` where
+  the contents are `{ "main.is_pirate": true }`), or
+* a YAML file of inputs prefixed with `@` (e.g., `@hello_defaults.yaml` where
+  the contents are `main.is_pirate: true`).
 
 Inputs are _incrementally_ applied, meaning that inputs specified later override
 inputs specified earlier. This enables you to do something like the following to
@@ -233,7 +233,7 @@ use a set of default parameters and iterate through sample names in Bash rather
 than create many individual input files.
 
 ```bash
-sprocket run example.wdl hello_defaults.json main.name="Ari"
+sprocket run example.wdl @hello_defaults.json main.name="Ari"
 ```
 
 Note that the above command does not specify a target with the `--target`
@@ -282,7 +282,7 @@ so by defining the input in a `hello_overrides.json` file:
 Then providing that file in the set of inputs to the workflow.
 
 ```shell
-sprocket run example.wdl hello_overrides.json main.name="Sprocket"
+sprocket run example.wdl @hello_overrides.json main.name="Sprocket"
 ```
 
 This produces the following output.

--- a/subcommands/run.md
+++ b/subcommands/run.md
@@ -32,11 +32,11 @@ Sprocket will indicate when it cannot infer the target.
 Inputs to a Sprocket run are provided as arguments passed after the WDL document
 name is provided. Each input can be specified as either
 
-* a key value pair (e.g., `main.is_pirate=true`)
-* a JSON file containing inputs (e.g., a `hello_defaults.json` file where the
-  contents are `{ "main.is_pirate": true }`)
-* a YAML file containing inputs (e.g. a `hello_defaults.yaml` file where the
-  contents are `main.is_pirate: true`)
+* a key-value pair (e.g., `main.is_pirate=true`),
+* a JSON file of inputs prefixed with `@` (e.g., `@hello_defaults.json` where
+  the contents are `{ "main.is_pirate": true }`), or
+* a YAML file of inputs prefixed with `@` (e.g., `@hello_defaults.yaml` where
+  the contents are `main.is_pirate: true`).
 
 Inputs are _incrementally_ applied, meaning that inputs specified later override
 inputs specified earlier. This enables you to do something like the following to
@@ -44,7 +44,35 @@ use a set of default parameters and iterate through sample names in Bash rather
 than create many individual input files.
 
 ```bash
-sprocket run example.wdl hello_defaults.json main.name="Ari"
+sprocket run example.wdl @hello_defaults.json main.name="Ari"
+```
+
+> [!IMPORTANT]
+>
+> The `@` prefix for input files is required. This follows the convention used
+> by tools such as `curl`, and it disambiguates input files from bare array
+> values (see [Array inputs](#array-inputs) below).
+
+### Array inputs
+
+Sprocket supports ergonomic ways to provide `Array` inputs on the command line
+without resorting to JSON syntax.
+
+**Repeated keys.** Specifying the same key multiple times collects the values
+into an array:
+
+```shell
+sprocket run example.wdl task.files=a.txt task.files=b.txt task.files=c.txt
+```
+
+A single occurrence of the key remains scalar.
+
+**Shell globbing.** Values from shell glob expansion are appended to the
+preceding key's array, which makes it easy to pass a set of files without
+repeating the key:
+
+```shell
+sprocket run example.wdl task.files=*.txt
 ```
 
 ### An example
@@ -86,7 +114,7 @@ so by defining the input in a `hello_overrides.json` file:
 Then providing that file in the set of inputs to the workflow.
 
 ```shell
-sprocket run example.wdl hello_overrides.json main.name="Sprocket"
+sprocket run example.wdl @hello_overrides.json main.name="Sprocket"
 ```
 
 This produces the following output.

--- a/subcommands/submit.md
+++ b/subcommands/submit.md
@@ -1,0 +1,59 @@
+# `sprocket submit`
+
+> [!CAUTION]
+>
+> This document describes the beta release of the `submit` command. This
+> functionality is considered experimental and may change in future releases.
+
+The `submit` command is a thin wrapper around the [Sprocket Server REST
+API](/subcommands/server#rest-api) that submits a WDL task or workflow to a
+running Sprocket server for remote execution. It mirrors the input and target
+semantics of `sprocket run`, so most invocations can be switched between the
+two commands by changing only the subcommand name.
+
+## Usage
+
+```shell
+sprocket submit <SOURCE> [INPUTS...] [OPTIONS]
+```
+
+The `SOURCE` argument can be either a local file path or a URL, matching the
+`--allowed-file-paths` and `--allowed-urls` configured on the server.
+
+Inputs follow the same syntax as [`sprocket run`](/subcommands/run#inputs),
+including key-value pairs, `@`-prefixed input files, and the ergonomic
+[array input forms](/subcommands/run#array-inputs).
+
+## Example
+
+Assuming a Sprocket server is running on the default host and port (see
+[`sprocket dev server`](/subcommands/server)):
+
+```shell
+sprocket submit example.wdl --target main name="World"
+```
+
+The command analyzes the WDL source, validates inputs locally, and then
+submits the run to the server.
+
+## Command-line options
+
+| Option | Description |
+|-|-|
+| `--host <HOST>` | The hostname of the running Sprocket server. Falls back to the value in the Sprocket config when not provided. |
+| `-p, --port <PORT>` | The port of the running Sprocket server. Falls back to the value in the Sprocket config when not provided. |
+| `-t, --target <NAME>` | The name of the task or workflow to submit. Required if the task or workflow has no inputs. |
+| `--index-on <OUTPUT_NAME>` | The output name to index on. When provided, the server indexes the run outputs using the specified output name as the key. |
+| `-m, --report-mode <MODE>` | The diagnostic reporting mode. |
+
+## Configuration
+
+The `host` and `port` used to reach the Sprocket server can be set in
+`sprocket.toml` under the `[server]` section, and are shared with the
+[`sprocket dev server`](/subcommands/server) command:
+
+```toml
+[server]
+host = "127.0.0.1"
+port = 8080
+```


### PR DESCRIPTION
Updates the `sprocket run` page to document the new ergonomic ways to provide `Array` inputs on the command line—repeated keys (`task.files=a.txt task.files=b.txt`) and shell globbing (`task.files=*.txt`)—as well as the breaking change requiring input files to be prefixed with `@` (e.g., `@inputs.json`). The `guided-tour` page is updated for consistency.

Also adds a new experimental-commands page for `sprocket submit`, a thin wrapper around the Sprocket server REST API that mirrors the input and target semantics of `sprocket run`.

Relates to stjude-rust-labs/sprocket#820 and stjude-rust-labs/sprocket#633.