### PR TITLE
docs: document `sprocket check` baselines

### DIFF
--- a/quickstart-checklist.md
+++ b/quickstart-checklist.md
@@ -30,6 +30,14 @@ development environment, CI pipeline, and workflow execution set up.
   maintain consistent style across your project. See the
   [format command](/subcommands/format) reference.
 
+- [ ] **Baseline existing diagnostics (optional).** If your codebase has
+  pre-existing lint or validation diagnostics that you cannot address all at
+  once, run `sprocket lint --generate-baseline` to capture
+  them in a `sprocket-baseline.toml` file. Subsequent runs of `sprocket
+  check` will ignore baselined diagnostics, so CI catches _new_ issues while
+  the existing backlog is cleaned up on your own schedule. See
+  [Baselines](/subcommands/check-lint#baselines) for details.
+
 - [ ] **Add the GitHub Action.** Add the
   [Sprocket GitHub Action](https://github.com/stjude-rust-labs/sprocket-action)
   to your CI pipeline so that linting and formatting are checked on every pull

--- a/subcommands/check-lint.md
+++ b/subcommands/check-lint.md
@@ -97,6 +97,54 @@ sprocket lint -e DoubleQuotes -e SnakeCase
 
 Will emit no warnings.
 
+## Baselines
+
+Adopting `sprocket check` on an existing codebase often surfaces a large
+number of pre-existing diagnostics. Fixing all of them before turning on CI
+enforcement can be impractical, but you may still want `sprocket check` to
+catch _new_ issues introduced by future work.
+
+A **baseline** captures the set of diagnostics that exist today and excludes
+them from both `sprocket check`'s output and its exit code calculation. Any
+diagnostic _not_ in the baseline still surfaces, so newly introduced issues
+fail CI while the existing backlog is cleaned up on your own schedule.
+
+### Generating a baseline
+
+Run `sprocket lint` (or `sprocket check`) with `--generate-baseline`:
+
+```bash
+sprocket lint --generate-baseline
+```
+
+This writes a `sprocket-baseline.toml` file in the current directory
+containing every diagnostic emitted by the run. Subsequent runs of
+`sprocket check` or `sprocket lint` automatically discover the baseline and
+suppress matching diagnostics.
+
+To override the default location, set `baseline` under the `[check]` table
+in your [sprocket config file]:
+
+```toml
+[check]
+baseline = "path/to/sprocket-baseline.toml"
+```
+
+To ignore the baseline for a single run (e.g., to see the full set of
+diagnostics), pass `--no-baseline`.
+
+### Stale entries
+
+If the baseline contains entries that no longer match any diagnostic in the
+current run — for example, because the underlying code was fixed —
+`sprocket check` fails and reports the stale entries with a suggestion to
+regenerate the baseline.
+
+### Editor integration
+
+The Sprocket LSP also respects `sprocket-baseline.toml`, so baselined
+diagnostics are suppressed in the editor as well as in CI.
+
 ## Filtering lint rules
 
 The set of active lint rules can be controlled via the `[check]` section in


### PR DESCRIPTION
A new `Baselines` section in `subcommands/check-lint.md` documents the support added in stjude-rust-labs/sprocket#810. It explains how to generate a baseline with `sprocket lint --generate-baseline`, ignore one for a single run via `--no-baseline`, and override the default path through the `[check] baseline` config option. The page also covers the stale-entry failure that prompts a regenerate when fixed code leaves orphaned entries behind, and notes that the LSP applies the baseline too.

The quickstart checklist gains an optional baseline step so teams adopting Sprocket can enforce `sprocket check` in CI without first fixing every existing diagnostic.

Targets `next` because the feature is unreleased.