### PR TITLE
docs: update for the v0.28.0 release

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -17,7 +17,7 @@ export default defineConfig({
     nav: [
       { text: "Documentation", link: "/overview" },
       {
-        text: "v0.27.0",
+        text: "v0.28.0",
         items: [
           {
             text: "Changelog",

--- a/concepts/provenance.md
+++ b/concepts/provenance.md
@@ -62,7 +62,7 @@ By default, Sprocket creates an `out/` directory in your current working
 directory to store all workflow outputs and provenance data. This location can
 be configured via:
 
-- The `-o, --output-dir` CLI flag (for `sprocket run` and `sprocket dev server`).
+- The `-o, --output-dir` CLI flag (for `sprocket run` and `sprocket dev server start`).
 - The `run.output_dir` configuration option (for run mode).
 - The `server.output_dir` configuration option (for server mode).
 
@@ -233,7 +233,7 @@ sprocket run pipeline_b.wdl -o ./pipeline-b-out ...
 
 ### Querying execution history
 
-The REST API (available via `sprocket dev server`) is the recommended way to query
+The REST API (available via `sprocket dev server start`) is the recommended way to query
 execution history. The API provides endpoints for listing sessions, runs, and
 tasks with filtering capabilities. See the
 [server documentation](/subcommands/server) for endpoint details and the

--- a/configuration/cache.md
+++ b/configuration/cache.md
@@ -120,8 +120,15 @@ even if metadata of the file remains unchanged. As the hash function must read
 every byte in the file, calculating a _strong_ digest for very large files may 
 greatly impact performance.
 
-You may opt-in to using _strong_ digests via the `run.task.digests` setting in 
-`sprocket.toml`:
+A _strongish_ digest offers a middle ground between the two: it hashes the
+file's size, last modified time, and the first 10 MiB of the file's contents.
+This catches changes to the beginning of a file that a _weak_ digest would miss,
+without paying the cost of reading very large files in full. It is similar to
+Cromwell's `fingerprint` call caching strategy.
+
+You may choose which digest mode to use via the `run.task.digests` setting in 
+`sprocket.toml`. Valid values are `"weak"` (the default), `"strongish"`, and 
+`"strong"`:
 
 ```toml
 [run.task]

--- a/installation.md
+++ b/installation.md
@@ -30,7 +30,7 @@ Every released version of `sprocket` is available through the GitHub Container
 Registry.
 
 ```bash
-docker run ghcr.io/stjude-rust-labs/sprocket:v0.27.0 -h
+docker run ghcr.io/stjude-rust-labs/sprocket:v0.28.0 -h
 ```
 
 ## Build from source
@@ -54,7 +54,7 @@ cargo install sprocket
 If desired, you can also check out a specific version of `sprocket`.
 
 ```shell
-cargo install sprocket@0.27.0
+cargo install sprocket@0.28.0
 ```
 
 ### GitHub

--- a/subcommands/analyzer.md
+++ b/subcommands/analyzer.md
@@ -12,6 +12,14 @@ LSP. For Neovim, the [`sprocket.nvim`][neovim] plugin provides similar
 integration. For other editors, you should search for how to set up an LSP with
 your editor of choice.
 
+## Configuration
+
+The analyzer honors the `[format]` section of your `sprocket.toml`, so
+formatting performed through the LSP (for example, "format document" in your
+editor) matches the output of [`sprocket format`](/subcommands/format). See the
+[configuration guide](/configuration/overview.md) for the available `[format]`
+options.
+
 ## Transports
 
 At the time of writing, `sprocket analyzer` only supports the standard I/O

--- a/subcommands/config.md
+++ b/subcommands/config.md
@@ -11,6 +11,15 @@ configuration file.
 configuration guide](/configuration/overview.md#load-order) and
 prints the effective configuration.
 
+`sprocket config schema` prints a [JSON schema](https://json-schema.org) for
+`sprocket.toml` to standard out. You can use this to validate your configuration
+file or to enable autocompletion and inline documentation in editors that
+support JSON schema for TOML.
+
+```shell
+sprocket config schema > sprocket.schema.json
+```
+
 Notably, while configuration is something we intend to put more effort into
 solving in the future, our existing documentation on what configuration options
 exist is lacking at the moment. You can expect the [configuration guide

--- a/subcommands/server.md
+++ b/subcommands/server.md
@@ -5,10 +5,22 @@
 > This document describes the beta release of the `server` command. This
 > functionality is considered experimental and may change in future releases.
 
-The `dev server` command starts Sprocket as an HTTP server, enabling remote workflow
-submission and monitoring through a REST API. This is useful for scenarios where
-you want to submit workflows from a separate machine or integrate Sprocket into
-larger systems.
+`sprocket dev server` is a group of run-management commands built around
+running Sprocket as an HTTP server, enabling remote workflow submission and
+monitoring through a REST API. This is useful for scenarios where you want to
+submit workflows from a separate machine or integrate Sprocket into larger
+systems.
+
+The group provides the following subcommands:
+
+| Subcommand | Description |
+|--------|-------------|
+| [`start`](#starting-the-server) | Run the HTTP API server for run execution. |
+| [`submit`](/subcommands/submit) | Submit a workflow to a running server. |
+| [`status`](#managing-runs) | Show the status of one or all runs. |
+| [`inspect`](#managing-runs) | Show detailed information about a run. |
+| [`cancel`](#managing-runs) | Cancel a running or queued run. |
+| [`retry`](#managing-runs) | Retry a previous run, optionally with input overrides. |
 
 ## Overview
 
@@ -25,7 +37,7 @@ consistent behavior between CLI and server-submitted workflows.
 ## Starting the server
 
 ```shell
-sprocket dev server --allowed-file-paths /path/to/workflows
+sprocket dev server start --allowed-file-paths /path/to/workflows
 ```
 
 At least one of `--allowed-file-paths` or `--allowed-urls` must be specified to
@@ -78,11 +90,66 @@ url = "sqlite://sprocket.db"
 | `database.url` | String | None | Database path. When omitted, defaults to `sprocket.db` within the output directory. When provided, relative paths resolve from the current working directory (not the output directory). |
 | `engine` | Object | `{}` | Engine configuration (see execution backends) |
 
+## Managing runs
+
+Once a server is running, you can manage its runs from the command line without
+talking to the REST API directly. These subcommands connect to the server using
+the `--host` and `--port` options (falling back to the `[server]` section of
+your `sprocket.toml` when not provided). A run may be referenced either by its
+UUID or by its human-readable generated name (e.g. `happy-dolphin-42`).
+
+### `status`
+
+Show the status of one run, or list all runs when no run is given:
+
+```shell
+# List all runs
+sprocket dev server status
+
+# Show a single run, filter the list, or emit raw JSON
+sprocket dev server status happy-dolphin-42
+sprocket dev server status --status running --limit 50
+sprocket dev server status --json
+```
+
+### `inspect`
+
+Show detailed information about a run, including per-status task counts and the
+output directory. Pass `--detailed` for a per-task breakdown, or `--json` for
+the raw response:
+
+```shell
+sprocket dev server inspect happy-dolphin-42 --detailed
+```
+
+### `cancel`
+
+Cancel a queued or running run:
+
+```shell
+sprocket dev server cancel happy-dolphin-42
+```
+
+### `retry`
+
+Resubmit a previous run, reusing its source, target, and inputs as the base.
+Any overrides use the same input syntax as
+[`submit`](/subcommands/submit) (`key=value`, `@file`, and repeated keys that
+append to arrays), and take precedence over the original run's values:
+
+```shell
+sprocket dev server retry happy-dolphin-42 workflow.threads=8
+```
+
 ## REST API
 
 The server exposes a REST API for managing workflow executions. Interactive
 documentation is available at `/api/v1/swagger-ui` when the server is running,
 and the OpenAPI specification can be retrieved from `/api/v1/openapi.json`.
+
+### Server
+
+- `GET /api/v1/info` - Get server metadata.
 
 ### Runs
 
@@ -94,12 +161,16 @@ Runs represent individual workflow executions.
 - `GET /api/v1/runs/{uuid}` - Get run details.
 - `POST /api/v1/runs/{uuid}/cancel` - Cancel a running workflow.
 - `GET /api/v1/runs/{uuid}/outputs` - Get run outputs.
+- `GET /api/v1/runs/{uuid}/tasks` - List a run's tasks. Supports pagination and
+  an optional `?status=` filter.
+- `GET /api/v1/runs/{uuid}/tasks/counts` - Get per-status task counts for a run.
 
 ### Sessions
 
 Sessions group related workflow submissions. Each `sprocket run` invocation
-creates its own session, while a running `sprocket dev server` instance creates a
-single session at startup that is shared by all workflows submitted to it.
+creates its own session, while a running `sprocket dev server start` instance
+creates a single session at startup that is shared by all workflows submitted to
+it.
 
 - `GET /api/v1/sessions` - List sessions.
 - `GET /api/v1/sessions/{uuid}` - Get session details.
@@ -118,12 +189,12 @@ Tasks represent individual task executions within a workflow run.
 
 ```shell
 # Start server allowing workflows from a local directory
-sprocket dev server \
+sprocket dev server start \
   --allowed-file-paths /home/user/workflows \
   --port 8080
 
 # Start server allowing workflows from GitHub
-sprocket dev server \
+sprocket dev server start \
   --allowed-urls "https://raw.githubusercontent.com/" \
   --port 8080
 ```

--- a/subcommands/submit.md
+++ b/subcommands/submit.md
@@ -1,11 +1,11 @@
-# `sprocket submit`
+# `sprocket dev server submit`
 
 > [!CAUTION]
 >
 > This document describes the beta release of the `submit` command. This
 > functionality is considered experimental and may change in future releases.
 
-The `submit` command is a thin wrapper around the [Sprocket Server REST
+The `dev server submit` command is a thin wrapper around the [Sprocket Server REST
 API](/subcommands/server#rest-api) that submits a WDL task or workflow to a
 running Sprocket server for remote execution. It mirrors the input and target
 semantics of `sprocket run`, so most invocations can be switched between the
@@ -14,7 +14,7 @@ two commands by changing only the subcommand name.
 ## Usage
 
 ```shell
-sprocket submit <SOURCE> [INPUTS...] [OPTIONS]
+sprocket dev server submit <SOURCE> [INPUTS...] [OPTIONS]
 ```
 
 The `SOURCE` argument can be either a local file path or a URL, matching the
@@ -30,7 +30,7 @@ Assuming a Sprocket server is running on the default host and port (see
 [`sprocket dev server`](/subcommands/server)):
 
 ```shell
-sprocket submit example.wdl --target main name="World"
+sprocket dev server submit example.wdl --target main name="World"
 ```
 
 The command analyzes the WDL source, validates inputs locally, and then

--- a/subcommands/test.md
+++ b/subcommands/test.md
@@ -295,7 +295,10 @@ build_bwa_db:
 ## Running unit tests
 
 ```text
-Usage: sprocket dev test [OPTIONS] [SOURCE]
+Usage: sprocket dev test [OPTIONS] [SOURCE] [COMMAND]
+
+Commands:
+  schema  Print the JSON schema for Sprocket test definition YAMLs to stdout
 
 Arguments:
   [SOURCE]
@@ -313,12 +316,21 @@ Options:
 
           If not specified and the `source` argument is a file, it's assumed that the current working directory is the workspace. This can be specified in addition to a source file if the CWD is not the right workspace.
 
-  -t, --include-tag <TAG>
+  -t, --target <TARGET>
+          Only run tests whose target (task/workflow) name contains the given filter
+
+  -f, --filter <FILTER>
+          Only run tests whose names contain the given filter
+
+      --exact
+          If set, filters are matched exactly rather than by substring
+
+  -i, --include-tag <TAG>
           Specific test tag that should be run.
 
           Can be repeated multiple times.
 
-  -f, --filter-tag <TAG>
+  -e, --exclude-tag <TAG>
           Filter out any tests with a matching tag.
 
           Can be repeated multiple times.
@@ -346,4 +358,21 @@ Options:
 
       --no-status
           Do not print results as tests complete
+```
+
+### Filtering which tests run
+
+Use `--target` (`-t`) to run only tests whose task or workflow name contains a
+substring, and `--filter` (`-f`) to run only tests whose _test name_ contains a
+substring. Pass `--exact` to match these filters exactly rather than by
+substring. These combine with the tag-based selection described above.
+
+### Generating a test schema
+
+`sprocket dev test schema` prints a [JSON schema](https://json-schema.org) for
+Sprocket test definition YAMLs to standard out. You can use this to validate
+test definition files or to power editor autocompletion.
+
+```shell
+sprocket dev test schema > test.schema.json
 ```


### PR DESCRIPTION
Updated the documentation for the v0.28.0 release, bumping the version references in `.vitepress/config.mts` and `installation.md` and revising the affected command pages.

The `sprocket dev server` command group was regrouped, so the docs now show `sprocket dev server start` for running the server and `sprocket dev server submit` for submitting, and they cover the new `status`, `inspect`, `cancel`, and `retry` run-management subcommands together with the `/api/v1/info` and run-scoped task endpoints. The `sprocket dev test` help block reflects the new `--target`, `--filter`, and `--exact` options and the `--include-tag`/`--exclude-tag` renames, and `sprocket dev test schema`, `sprocket config schema`, the `strongish` content digest mode, and the analyzer honoring `[format]` configuration are now documented.