### PR TITLE
Fix broken explain example in Guided Tour

### DIFF
--- a/guided-tour.md
+++ b/guided-tour.md
@@ -21,23 +21,41 @@ development. Sprocket contains both the `check` and `lint` (shortcut for `check
 You can see a list of all of the rules Sprocket contains by running `sprocket
 explain -h`. You can dive into any of the rules Sprocket includes by running
 `sprocket explain <RULE>`. For example, if we wanted to learn more about the
-`ImportSorted` rule, we could do the following.
+`ImportPlacement` rule, we could do the following.
 
 ```shell
-sprocket explain ImportSorted
+sprocket explain ImportPlacement
 ```
 
-This command gives the following description of the `ImportSorted` rule.
+This command gives the following description of the `ImportPlacement` rule.
 
 ```txt
-ImportSorted [Sorting]
-Ensures that imports are sorted lexicographically.
+ImportPlacement [Clarity]
+Ensures that imports are placed between the version statement and any document items.
 
-Imports should be sorted lexicographically to make it easier to find 
-specific imports. This rule ensures that imports are sorted in a 
-consistent manner. Specifically, the desired sort can be achieved
-with a GNU compliant `sort` and `LC_COLLATE=C`. No comments are
-permitted within an import statement.
+All import statements should follow the WDL version declaration with one empty line between the version and the first import statement.
+```
+
+For example, this ordering triggers the rule:
+
+```wdl
+version 1.2
+
+workflow example {
+}
+
+import "example2.wdl"
+```
+
+Use this instead:
+
+```wdl
+version 1.2
+
+import "example2.wdl"
+
+workflow example {
+}
 ```
 
 We encourage you to explore the existing validation and linting rules supported


### PR DESCRIPTION
The Guided Tour opens its `sprocket explain` example using the `ImportSorted` rule, which no longer exists, having either been removed or renamed. Running the tour's first command as written now fails with an "invalid value 'ImportSorted'" error, which is a rough first experience since it's the very first command the tour has a new user run.

This swaps the example to `ImportPlacement`, a current rule, and updates the quoted description to match the tool's actual output. The description block is restructured slightly so the WDL code examples in that output render as their own fenced blocks instead of colliding with the surrounding code fence.