### PR TITLE
docs: describe `--index-on` as an index path, not an output name

### DIFF
--- a/concepts/provenance.md
+++ b/concepts/provenance.md
@@ -95,8 +95,9 @@ the run directory.
 │       │           └── work/         # Task working directory
 │       └── _latest -> <timestamp>/   # Symlink to most recent run
 └── index/                            # Optional output indexing
-    └── <output_name>/
-        └── outputs.json              # Symlink to run outputs
+    └── <index_path>/                 # The path given to `--index-on`
+        ├── outputs.json              # Symlink to run outputs
+        └── <outputs>                 # Symlinks to `File`/`Directory` outputs
 ```
 
 #### Workflow runs
@@ -127,8 +128,9 @@ subdirectory under `calls/`. Each call directory then contains the same
 │       │                   └── work/
 │       └── _latest -> <timestamp>/
 └── index/
-    └── <output_name>/
-        └── outputs.json
+    └── <index_path>/
+        ├── outputs.json
+        └── <outputs>
 ```
 
 ### The `_latest` symlink
@@ -183,14 +185,14 @@ execution attempts, which is valuable for debugging intermittent failures.
 
 ## Output indexing
 
-When the `--index-on` flag is provided, Sprocket indexes run outputs by the
-specified output name. For each run, a symlink is created under
-`index/<output_name>/` pointing to the run's `outputs.json` file. This enables
-efficient lookup of runs by output values without scanning the entire `runs/`
-directory.
+The `--index-on` flag takes a path within the output directory's `index/`
+directory. For each run, Sprocket symlinks the run's `outputs.json` along with
+every output that is a `File`, a `Directory`, or an array of them into
+`index/<index_path>/`, which gives results a stable location per project,
+experiment, or sample without walking `runs/`.
 
 ```shell
-# Run a workflow with output indexing on the `greeting` output
+# Index this run's outputs under `index/greeting/`
 sprocket run hello.wdl -t hello --index-on greeting
 ```
 
@@ -199,6 +201,16 @@ The resulting index entry is a relative symlink:
 ```
 index/greeting/outputs.json -> ../../runs/hello/<timestamp>/outputs.json
 ```
+
+An index path is relative and cannot contain `.` or `..` components; Sprocket
+rejects anything else before the run starts, which keeps every entry inside
+`index/`. Because Sprocket uses the path verbatim, group results by a value of
+your own choosing by interpolating that value into the index path in your shell.
+
+Outputs that live outside the output directory are reported and left out of the
+index. A `File` input that a task passes straight through to an output is the
+usual case: its path belongs to the input rather than to the run, so neither a
+relative symlink nor a database entry can describe it.
 
 ## Portability
 

--- a/subcommands/run.md
+++ b/subcommands/run.md
@@ -155,9 +155,12 @@ sprocket run example.wdl --target main name="World" --suffix experiment-1
 This changes the run directory from `out/runs/main/<timestamp>/` to
 `out/runs/main/<timestamp>_experiment-1/`.
 
-The `--index-on` flag enables output indexing, creating symlinks under
-`<output_dir>/index/<output_name>/` for efficient lookup of runs by output
-values.
+The `--index-on` flag takes a path within `<output_dir>/index/` and symlinks the
+run's `outputs.json` along with every output that is a `File`, a `Directory`, or
+an array of them into it, giving results a stable location that does not change
+with each run's timestamp. The path is relative, cannot contain `.` or `..`
+components, and is used verbatim, so group results by a value of your own
+choosing by interpolating that value into the index path in your shell:
 
 ```shell
 sprocket run hello.wdl -t hello --index-on greeting

--- a/subcommands/submit.md
+++ b/subcommands/submit.md
@@ -43,7 +43,7 @@ submits the run to the server.
 | `--host <HOST>` | The hostname of the running Sprocket server. Falls back to the value in the Sprocket config when not provided. |
 | `-p, --port <PORT>` | The port of the running Sprocket server. Falls back to the value in the Sprocket config when not provided. |
 | `-t, --target <NAME>` | The name of the task or workflow to submit. Required if the task or workflow has no inputs. |
-| `--index-on <OUTPUT_NAME>` | The output name to index on. When provided, the server indexes the run outputs using the specified output name as the key. |
+| `--index-on <INDEX_PATH>` | A path within the server output directory's `index/` directory to index the run outputs under. The path must be relative and cannot contain `.` or `..` components. |
 | `-m, --report-mode <MODE>` | The diagnostic reporting mode. |
 
 ## Configuration


### PR DESCRIPTION
The provenance page described `--index-on` as taking the name of an output, and its example indexed on `greeting`, which is an input in the `hello.wdl` sample. Sprocket treats the value as a path within the output directory's `index/` directory, so a reader following the page could not tell what the flag indexes on.

The `Output indexing` section now states the path semantics, shows the resulting relative symlinks for both `outputs.json` and the run's file outputs, records that a path must be relative and free of `.` and `..` components, and shows how to group results by a value by interpolating it in the shell. The two directory trees use `<index_path>` in place of `<output_name>`, and the `sprocket run` and `dev server submit` pages match.

Fixes the documentation half of stjude-rust-labs/sprocket#704. The panic and validation behavior described here lands in stjude-rust-labs/sprocket via the branch for that issue.