### PR TITLE
docs: python bindings page

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -102,6 +102,10 @@ export default defineConfig({
         text: "Editor Integrations",
         items: [{ text: "Visual Studio Code", link: "/vscode/getting-started", docFooterText: "Editor Integrations &gt; Visual Studio Code" }],
       },
+      {
+        text: "API",
+        items: [{ text: "Python Bindings", link: "/python-bindings", docFooterText: "API &gt; Python Bindings" }],
+      },
     ],
     socialLinks: [
       { icon: "github", link: "https://github.com/stjude-rust-labs/sprocket" },

--- a/python-bindings.md
+++ b/python-bindings.md
@@ -20,6 +20,7 @@ many common platforms and Python versions. If you install `sprocket-bio` on a pl
 not have a precompiled wheel, you will need the latest stable release of the [Rust
 compiler](https://rust-lang.org/) in order to build from source.
 
-## API Documentation
+## Documentation
 
-The Python bindings's API docs are published online at <https://sprocket-bio.readthedocs.io/>.
+You can find the Python binding's API docs and several examples online at
+<https://sprocket-bio.readthedocs.io/>.

--- a/python-bindings.md
+++ b/python-bindings.md
@@ -1,0 +1,25 @@
+# Python Bindings
+
+Sprocket provides Python APIs that you can use to programmatically analyze WDL documents. These
+Python bindings expose a subset of the Rust APIs included in Sprocket's
+[`wdl`](https://crates.io/crates/wdl) crate.
+
+## Installation
+
+Sprocket's Python bindings are available on PyPI as
+[`sprocket-bio`](https://pypi.org/project/sprocket-bio/). It requires Python 3.10 or greater, and
+can be installed using [Pip](https://pip.pypa.io/):
+
+```bash
+pip install sprocket-bio
+```
+
+Sprocket publishes precompiled
+[wheels](https://packaging.python.org/en/latest/specifications/binary-distribution-format/) for
+many common platforms and Python versions. If you install `sprocket-bio` on a platform that does
+not have a precompiled wheel, you will need the latest stable release of the [Rust
+compiler](https://rust-lang.org/) in order to build from source.
+
+## API Documentation
+
+The Python bindings's API docs are published online at <https://sprocket-bio.readthedocs.io/>.


### PR DESCRIPTION
This PR adds a short page on Sprocket's Python bindings, including how to install it and where to find its documentation.

cc @claymcleod 